### PR TITLE
Add .env.example and update README

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,14 @@
+# Database username
+DB_USER=
+
+# Database host address
+DB_HOST=
+
+# Name of the PostgreSQL database
+DB_NAME=
+
+# User password for the database
+DB_PASSWORD=
+
+# Database port (usually 5432)
+DB_PORT=

--- a/readme.md
+++ b/readme.md
@@ -52,7 +52,7 @@ README.md        → Project documentation
 
 3. **Set up PostgreSQL**:
    - Create database and `items` table using `schema.sql` (optional)
-   - Add your DB credentials to `.env`
+   - Copy `.env.example` to `.env` and fill in your database credentials
 
 4. **Run the server**:
    ```bash


### PR DESCRIPTION
## Summary
- provide `.env.example` with documented environment variables
- guide users to copy `.env.example` when configuring the database

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684eac1b1ae08329811b9ed774288aa0